### PR TITLE
ADD review

### DIFF
--- a/models/Review.js
+++ b/models/Review.js
@@ -6,13 +6,13 @@ const reviewSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: "User",
     required: [true, "Please provide the user mongoId"],
-    validate: [validator.isMongoId, "Please provide a valid user mongoId"],
+    //validate: [validator.isMongoId, "Please provide a valid user mongoId"],
   },
   beer: {
     type: mongoose.Schema.Types.ObjectId,
     ref: "Beer",
     required: [true, "Please provide the beer mongoId"],
-    validate: [validator.isMongoId, "Please provide a valid beer mongoId"],
+    //validate: [validator.isMongoId, "Please provide a valid beer mongoId"],
   },
   writtenDate: {
     type: Date,

--- a/models/Review.js
+++ b/models/Review.js
@@ -52,30 +52,6 @@ const reviewSchema = new mongoose.Schema({
   },
 });
 
-// reviewSchema.statics.getStats = function (id, isUser) {
-//   try {
-//     const match = isUser
-//       ? { user: mongoose.Types.ObjectId(id) }
-//       : { beer: mongoose.Types.ObjectId(id) };
-//     const stats = Review.aggregate([
-//       { $match: match },
-//       {
-//         $group: {
-//           _id: null,
-//           averageRating: { $avg: "$rating" },
-//           averageBody: { $avg: "$body" },
-//           averageAroma: { $avg: "$aroma" },
-//           averageSparkling: { $avg: "$sparkling" },
-//         },
-//       },
-//     ]);
-
-//     return stats;
-//   } catch (err) {
-//     return err;
-//   }
-// };
-
 reviewSchema.statics.getComments = function (id, isUser) {
   try {
     const match = isUser

--- a/models/Review.js
+++ b/models/Review.js
@@ -14,7 +14,7 @@ const reviewSchema = new mongoose.Schema({
     required: [true, "Please provide the beer mongoId"],
     //validate: [validator.isMongoId, "Please provide a valid beer mongoId"],
   },
-  writtenDate: {
+  createdAt: {
     type: Date,
     required: [true, "Please provide the written date"],
     validate: [validator.isDate, "Please provide a valid written date"],

--- a/routes/api/beers/controller.js
+++ b/routes/api/beers/controller.js
@@ -76,7 +76,7 @@ const getBeerComments = async (req, res, next) => {
   try {
     const { beerId } = req.params;
     const comments = await Review.getComments(beerId, false)
-      .sort("writtenDate")
+      .sort("createdAt")
       .lean();
 
     res.json(comments);

--- a/routes/api/beers/controller.js
+++ b/routes/api/beers/controller.js
@@ -24,8 +24,8 @@ const searchBeer = async (req, res, next) => {
 
 const getBeer = async (req, res, next) => {
   try {
-    const { id } = req.params;
-    const beer = await leanQueryByOptions(Beer.findById(id));
+    const { beerId } = req.params;
+    const beer = await leanQueryByOptions(Beer.findById(beerId));
 
     res.json(beer);
   } catch (err) {
@@ -74,8 +74,8 @@ const scanPhoto = async (req, res, next) => {
 
 const getBeerComments = async (req, res, next) => {
   try {
-    const { id } = req.params;
-    const comments = await Review.getComments(id, false)
+    const { beerId } = req.params;
+    const comments = await Review.getComments(beerId, false)
       .sort("writtenDate")
       .lean();
 
@@ -87,9 +87,11 @@ const getBeerComments = async (req, res, next) => {
 
 const getBeerRecommendations = async (req, res, next) => {
   try {
-    const { id } = req.params;
+    const { beerId } = req.params;
     const beers = await leanQueryByOptions(Beer.find());
-    const baseBeerIndex = beers.findIndex((beer) => beer._id.toString() === id);
+    const baseBeerIndex = beers.findIndex(
+      (beer) => beer._id.toString() === beerId
+    );
     const recommendations = sortBeersByEuclideanDistance(
       beers[baseBeerIndex],
       beers

--- a/routes/api/beers/index.js
+++ b/routes/api/beers/index.js
@@ -7,6 +7,9 @@ const {
   getBeerRecommendations,
   scanPhoto,
 } = require("./controller");
+const reviewsRouter = require("../reviews");
+
+router.use("/:beerId/reviews", reviewsRouter);
 
 router.route("/scan").post(scanPhoto);
 

--- a/routes/api/beers/index.js
+++ b/routes/api/beers/index.js
@@ -12,10 +12,10 @@ router.route("/scan").post(scanPhoto);
 
 router.route("/search").get(searchBeer);
 
-router.route("/:id").get(getBeer);
+router.route("/:beerId").get(getBeer);
 
-router.route("/:id/comments").get(getBeerComments);
+router.route("/:beerId/comments").get(getBeerComments);
 
-router.route("/:id/recommendations").get(getBeerRecommendations);
+router.route("/:beerId/recommendations").get(getBeerRecommendations);
 
 module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -2,8 +2,10 @@ const router = require("express").Router();
 
 const users = require("./users");
 const beers = require("./beers");
+const reviews = require("./reviews");
 
 router.use("/users", users);
 router.use("/beers", beers);
+router.use("/reviews", reviews);
 
 module.exports = router;

--- a/routes/api/reviews/controller.js
+++ b/routes/api/reviews/controller.js
@@ -1,0 +1,37 @@
+const createError = require("http-errors");
+
+const Beer = require("../../../models/Beer");
+const Review = require("../../../models/Review");
+
+const createReview = async (req, res, next) => {
+  try {
+    /**
+     * 리뷰 플로우
+     * 1. 클라에서 데이터를 보낸다.
+     * 2. 받아서 리뷰, 비어, 유저를 다 업데이트해준다. (트랜잭션)
+     * 3.
+     */
+    const {
+      beer,
+      review: { rating, body, aroma, sparkling },
+      comment,
+    } = req.body;
+    await Review.create({
+      beer,
+      writtenDate: new Date().toISOString(),
+      comment,
+      rating,
+      body,
+      aroma,
+      sparkling,
+    });
+
+    res.json();
+  } catch (err) {
+    next(createError(500, err));
+  }
+};
+
+module.exports = {
+  createReview,
+};

--- a/routes/api/reviews/controller.js
+++ b/routes/api/reviews/controller.js
@@ -1,33 +1,96 @@
 const createError = require("http-errors");
+const mongoose = require("mongoose");
 
+const User = require("../../../models/User");
 const Beer = require("../../../models/Beer");
 const Review = require("../../../models/Review");
 
 const createReview = async (req, res, next) => {
+  /**
+   * 리뷰 플로우
+   * 1. 클라에서 데이터를 보낸다.
+   * 2. 받아서 리뷰, 비어, 유저를 다 업데이트해준다. (트랜잭션)
+   * 3.
+   */
+
+  //밥먹고 와서 할거: 트랜잭션으로 모두 업뎃 or 모두 페일
+  const {
+    beerId,
+    review: { rating, body, aroma, sparkling },
+    comment,
+  } = req.body;
+
   try {
-    /**
-     * 리뷰 플로우
-     * 1. 클라에서 데이터를 보낸다.
-     * 2. 받아서 리뷰, 비어, 유저를 다 업데이트해준다. (트랜잭션)
-     * 3.
-     */
-    const {
-      beer,
-      review: { rating, body, aroma, sparkling },
-      comment,
-    } = req.body;
-    await Review.create({
-      beer,
-      writtenDate: new Date().toISOString(),
-      comment,
-      rating,
-      body,
-      aroma,
-      sparkling,
+    const review = await Review.findOne({
+      user: mongoose.Types.ObjectId("60841704df5cc79f9a3f7a4d"),
+      beer: mongoose.Types.ObjectId("60801ed238f2c931eaf6a259"), //beerId
     });
+
+    if (review) {
+      next(createError(421, "Misdirected Request"));
+    }
+  } catch (err) {
+    next(createError(500, err));
+  }
+
+  const session = await mongoose.startSession();
+
+  try {
+    session.startTransaction();
+
+    await Review.create(
+      [
+        {
+          user: mongoose.Types.ObjectId("60841704df5cc79f9a3f7a4d"),
+          /** 이거 local에 oid 박아서 할지 아니면 find해서 거기서 oid 가져올지 세팅해야됨 */
+          beer: mongoose.Types.ObjectId("60801ed238f2c931eaf6a259"),
+          /**beer 진짜 데이터 들올땐 이미 oid임  beerId*/
+          writtenDate: new Date().toISOString(),
+          comment,
+          rating,
+          body,
+          aroma,
+          sparkling,
+        },
+      ],
+      { session }
+    );
+    //id 나중에 res.locals.user로 바껴야댐
+    await User.findByIdAndUpdate(
+      mongoose.Types.ObjectId("60841704df5cc79f9a3f7a4d"),
+      {
+        $inc: {
+          reviewCounts: 1,
+          totalRating: rating,
+          totalBody: body,
+          totalAroma: aroma,
+          totalSparkling: sparkling,
+        },
+      },
+      { new: true, session }
+    );
+    await Beer.findByIdAndUpdate(
+      mongoose.Types.ObjectId("60801ed238f2c931eaf6a259"),
+      {
+        $inc: {
+          reviewCounts: 1,
+          totalRating: "AAAAA",
+          totalBody: body,
+          totalAroma: aroma,
+          totalSparkling: sparkling,
+        },
+      },
+      { new: true, session }
+    );
+
+    await session.commitTransaction();
+    session.endSession();
 
     res.json();
   } catch (err) {
+    await session.abortTransaction();
+    session.endSession();
+    console.log(err);
     next(createError(500, err));
   }
 };

--- a/routes/api/reviews/index.js
+++ b/routes/api/reviews/index.js
@@ -4,4 +4,6 @@ const { createReview } = require("./controller");
 
 router.route("/new").post(createReview);
 
+router.route("/").get(getBeerReview);
+
 module.exports = router;

--- a/routes/api/reviews/index.js
+++ b/routes/api/reviews/index.js
@@ -1,0 +1,7 @@
+const router = require("express").Router();
+
+const { createReview } = require("./controller");
+
+router.route("/new").post(createReview);
+
+module.exports = router;

--- a/routes/api/reviews/index.js
+++ b/routes/api/reviews/index.js
@@ -1,9 +1,9 @@
 const router = require("express").Router();
 
-const { createReview } = require("./controller");
+const { createReview, getReview, updateReview } = require("./controller");
 
 router.route("/new").post(createReview);
 
-router.route("/").get(getBeerReview);
+router.route("/single").get(getReview).patch(updateReview);
 
 module.exports = router;

--- a/routes/api/users/controller.js
+++ b/routes/api/users/controller.js
@@ -50,8 +50,8 @@ const signInUser = async (req, res, next) => {
 
 const getUser = async (req, res, next) => {
   try {
-    const { id } = req.params;
-    const user = await leanQueryByOptions(User.findById(id));
+    const { userId } = req.params;
+    const user = await leanQueryByOptions(User.findById(userId));
 
     res.json(user);
   } catch (err) {
@@ -61,8 +61,8 @@ const getUser = async (req, res, next) => {
 
 const getUserRecommendations = async (req, res, next) => {
   try {
-    const { id } = req.params;
-    const user = await leanQueryByOptions(User.findById(id));
+    const { userId } = req.params;
+    const user = await leanQueryByOptions(User.findById(userId));
     const beers = await leanQueryByOptions(Beer.find());
     const recommendations = sortBeersByEuclideanDistance(user, beers).slice(
       0,

--- a/routes/api/users/index.js
+++ b/routes/api/users/index.js
@@ -7,8 +7,8 @@ router.route("/sign-in").post(signInUser);
 
 router.all("*", authorizeUser);
 
-router.route("/:id").get(getUser);
+router.route("/:userId").get(getUser);
 
-router.route("/:id/recommendations").get(getUserRecommendations);
+router.route("/:userId/recommendations").get(getUserRecommendations);
 
 module.exports = router;


### PR DESCRIPTION
-ADD getReview
-ADD createReview
-ADD updateReview
-FIX beer model property name "writtenDate "-> "createdAt"
-FIX beer/user param routes' names = ":id" -> ":beerId"/":userId"

++get/updateReview route가 domain/api/beers/:beerId/reviews/single 로 들어가게해놨는데 더 좋은 루트 이름 있는지 추천받고싶습니다.
single로 한 이유는 reviewId를 얻을 방법이 있지만 매우 시간 많이들어서 userId와 beerId를 통해 쿼리하기때문에 마땅히 붙일게 생각이 안나서
single이라 했습니다.

++create/update가 유사한 점이 무척많은데 근본적으로 create는 혹시 모를 사태를 대비해서 이미 유저가 비어에 대한 리뷰를 남겼는데 다시 new로 접속된 에러를 막아놓았습니다. 그리고 beer랑 user update하는 게 살짝 다릅니다. 아직도 합치고싶은 욕구가 남아있네요. 좋은 방법 잇으면 조언 부탁드려요.

++Review user/beer validator는 잠시 코멘트 처리해놨습니다. 저는 처음부터 mongoId 오브젝트로 만들고 리턴하게 해놨는데 막상 써보니 validator가 string이 mongoId 룰에 따라 만들어진건지 체크하는거여서 코멘트 처리해놨습니다. 차후에 여기에 따를지 선택한 후 변경하겠습니다.